### PR TITLE
Adding the key mapping for isOrphaned

### DIFF
--- a/src/main/java/com/perforce/p4java/core/file/IFileSpec.java
+++ b/src/main/java/com/perforce/p4java/core/file/IFileSpec.java
@@ -302,6 +302,17 @@ public interface IFileSpec extends IFileOperationResult {
 	void setDate(Date date);
 
 	/**
+	 * @return true if the associated file is orphaned.
+	 */
+	boolean isOrphaned();
+
+	/** Set whether this file is orphaned
+	 *
+	 * @param isOrphaned is this file orphaned
+	 */
+	public void setOrphaned(boolean isOrphaned);
+
+	/**
 	 * @return true if the associated file has been locked.
 	 */
 	boolean isLocked();

--- a/src/main/java/com/perforce/p4java/impl/generic/core/file/FileSpec.java
+++ b/src/main/java/com/perforce/p4java/impl/generic/core/file/FileSpec.java
@@ -61,6 +61,7 @@ import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.FROM_
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.HAVEREV;
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.HOW;
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.LOCAL_FILE;
+import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.IS_ORPHANED;
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.OTHERLOCK;
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.OTHER_ACTION;
 import static com.perforce.p4java.impl.mapbased.rpc.func.RpcFunctionMapKey.OURLOCK;
@@ -144,7 +145,7 @@ public class FileSpec extends ServerResource implements IFileSpec {
 	private int workRev = NO_FILE_REVISION;
 	private String howResolved = null;
 	private FileAction otherAction = null;
-
+	private boolean orphaned = false;
 	private boolean locked = false;
 
 	private String diffStatus = null;
@@ -394,6 +395,10 @@ public class FileSpec extends ServerResource implements IFileSpec {
 					Log.error("Error parsing the '%S' in the FileSpec constructor: %s", TIME, nfe.getLocalizedMessage());
 					Log.exception(nfe);
 				}
+			}
+
+			if(map.containsKey(IS_ORPHANED)) {
+				setOrphaned(true);
 			}
 
 			setLocked(nonNull(map.get(OURLOCK)) || nonNull(map.get(OTHERLOCK)));
@@ -692,6 +697,11 @@ public class FileSpec extends ServerResource implements IFileSpec {
 	}
 
 	@Override
+	public boolean isOrphaned() {
+		return orphaned;
+	}
+
+	@Override
 	public boolean isLocked() {
 		return locked;
 	}
@@ -882,6 +892,11 @@ public class FileSpec extends ServerResource implements IFileSpec {
 	@Override
 	public void setOtherAction(FileAction otherAction) {
 		this.otherAction = otherAction;
+	}
+
+	@Override
+	public void setOrphaned(boolean isOrphaned) {
+		this.orphaned = isOrphaned;
 	}
 
 	@Override

--- a/src/main/java/com/perforce/p4java/impl/mapbased/rpc/func/RpcFunctionMapKey.java
+++ b/src/main/java/com/perforce/p4java/impl/mapbased/rpc/func/RpcFunctionMapKey.java
@@ -115,6 +115,7 @@ public class RpcFunctionMapKey {
 	public static final String IPADDR = "ipaddr";
 	public static final String IS_GROUP = "isgroup";
 	public static final String ISMAPPED = "isMapped";
+	public static final String IS_ORPHANED = "isOrphaned";
 	public static final String KEY = "key";
 	public static final String LABEL_REC_DELETED = "labelRecDeleted";
 	public static final String LABEL = "label";


### PR DESCRIPTION
Perforce servers provide a (K, V) pair of ("isOrphaned", "") when a file was opened but no longer associated with a client/workspace.

There is no way to filter or partition these files via the FileSpec/IFileSpec response when using perforce commands that return a list of IFileSpec. 

This functionality would provide the ability to simply check if a file is considered orphaned by the user using the 'isOrphaned()' getter on the file.